### PR TITLE
Removed global config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-export config.json
 __pycache__

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ Clink the links to see the parameters for each type. Additional key/value argume
 
 After configurating the export script, run it using Python. When first run, the configuration will attempt to load a saved config file. If not found, it will search for following automatically:
 * The location of OpenSCAD on your system. This will search the default install locations for Windows, MacOS, and Linux.
-* The root directory of the current git project, or the parent of the `scad_export` folder if a git project is not found.
+* The root directory of the current git project, or the directory of your Python script if a git project is not found.
 * A `.scad` file in the project root that defines each part to export.
     * The auto-detection looks specifically for files ending with the name `export map.scad`, but any name can be used if manually selecting a file.
 * A folder to export the rendered files to.
 
 For each of the above, the script will issue a command line prompt that will let you select from the available defaults detected. If the script fails to find a valid default, or if you choose not to use the default, you'll be prompted for the value to use. Custom values can be entered using file or directory picker (recommended), or using the command line directly.
 
-The values you select will be saved to a file called `config.json` in either `[user home]/.config/scad_export/config.json` or your current Python working directory if your user folder can't be found or written to. The values in this file will be checked each time the script is run, but won't reprompt unless they are found to be invalid. To force a reprompt, delete the specific value you want to be reprompted for, or delete the `config.json` file.
+The values you select will be saved to a file called `export config.json` in the same directory as your Python script. The values in this file will be checked each time the script is run, but won't reprompt unless they are found to be invalid. To force a reprompt, delete the specific value you want to be reprompted for, or delete the `export config.json` file.
 
 In addition to the user-selected values above, the export config also supports optional [export configuration](#export-configuration) such as setting the default export type for model files, or configuring how many threads to use while exporting.
 
@@ -113,7 +113,7 @@ Supports exporting an image of a model to the PNG format.
 High-level overview of the files in this project.
 
 * export_config.py
-    * Primary configuration for the export. Contains default values. Reads and writes `config.json`.
+    * Primary configuration for the export. Contains default values. Reads and writes `export config.json`.
 * export.py
     * Formats arguments and invokes OpenSCAD in parallel for exporting parts.
 * exportable.py


### PR DESCRIPTION
Updated:

- Config location is now relative to the script used to invoke the export logic.
- Refactored git project root logic to separate function.

Removed:

 - Global config file. Only the OpenSCAD location was shared, making it not worth the trouble of solving config collision issues.