### PR TITLE
Append user arguments to file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,11 @@ To set these options create an instance of the `ExportConfig` and pass the desir
 
 ### NamingFormat
 
-The format to use when generating the names of output files and folders.
+The format to use when generating the names of output files and folders. When formatting the name, the following will also be appended:
+
+1. The file format (e.g. `.stl`).
+2. The count if the quantity of the exportable is greater than `1`.
+3. Any additional args given in the exportable definition. In a file like the [export example](https://github.com/CharlesLenk/scad-export/blob/main/tests/examples/export_example.py), the first cube would have '(x-5) (y-5) (z-5)' appended to the file name.
 
 #### Import Path
 
@@ -138,7 +142,7 @@ The format to use when generating the names of output files and folders.
 
 |Name|Description|
 |-|-|
-|NONE|Use the folder and file name exactly as written.|
+|NONE|Use the folder and file name as written. If using this option, additional args will not be appended to the file name.|
 |TITLE_CASE|Capitalize each word and use space as a separator.|
 |SNAKE_CASE|Lower-case each word and use underscore as a separator.|
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The format to use when generating the names of output files and folders. When fo
 
 1. The file format (e.g. `.stl`).
 2. The count if the quantity of the exportable is greater than `1`.
-3. Any additional args given in the exportable definition. In a file like the [export example](https://github.com/CharlesLenk/scad-export/blob/main/tests/examples/export_example.py), the first cube would have '(x-5) (y-5) (z-5)' appended to the file name.
+3. Any additional user-defined args given in the exportable definition. For example, in the [export example script](https://github.com/CharlesLenk/scad-export/blob/main/tests/examples/export_example.py), the first cube would have '(x-5) (y-5) (z-5)' appended to the file name.
 
 #### Import Path
 
@@ -142,7 +142,7 @@ The format to use when generating the names of output files and folders. When fo
 
 |Name|Description|
 |-|-|
-|NONE|Use the folder and file name as written. If using this option, additional args will not be appended to the file name.|
+|NONE|Use the folder and file name as written. If using this option, the file format and quantity will still be appended to the file name, but additional args will not.|
 |TITLE_CASE|Capitalize each word and use space as a separator.|
 |SNAKE_CASE|Lower-case each word and use underscore as a separator.|
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scad_export"
-version = "1.2"
+version = "1.3"
 authors = [
   { name="Charles Lenk", email="lenk.charles@gmail.com" },
 ]

--- a/src/scad_export/export.py
+++ b/src/scad_export/export.py
@@ -34,8 +34,7 @@ def _format_part_name(name, naming_format: NamingFormat, file_format, user_args,
     formatted_name = name
     if naming_format is not NamingFormat.NONE:
         for key, value in user_args.items():
-            if key != 'name':
-                formatted_name += '_({}-{})'.format(key, value)
+            formatted_name += '_({}-{})'.format(key, value)
     formatted_name += ('_{}'.format(count) if count > 1 else '')
     formatted_name = _format_name(formatted_name, naming_format)
     return formatted_name + file_format
@@ -47,6 +46,7 @@ def _get_exportable_args(exportable: Exportable, config: ExportConfig):
     ]
     if config.manifold_supported:
         args.append('--enable=manifold')
+    args.append('-Dname="{}"'.format(exportable.name))
     for arg, value in exportable.user_args.items():
         if isinstance(value, Number):
             args.append('-D{}={}'.format(arg, value))

--- a/src/scad_export/export.py
+++ b/src/scad_export/export.py
@@ -30,10 +30,15 @@ def _format_name(name, naming_format: NamingFormat):
 def _format_path_name(path, naming_format: NamingFormat):
     return '/'.join([_format_name(folder, naming_format) for folder in path.split('/')])
 
-def _format_part_name(name, naming_format: NamingFormat, format, count = 1):
-    formatted_name = name + ('_{}'.format(count) if count > 1 else '')
+def _format_part_name(name, naming_format: NamingFormat, file_format, user_args, count = 1):
+    formatted_name = name
+    if naming_format is not NamingFormat.NONE:
+        for key, value in user_args.items():
+            if key != 'name':
+                formatted_name += '_({}-{})'.format(key, value)
+    formatted_name += ('_{}'.format(count) if count > 1 else '')
     formatted_name = _format_name(formatted_name, naming_format)
-    return formatted_name + format
+    return formatted_name + file_format
 
 def _get_exportable_args(exportable: Exportable, config: ExportConfig):
     args=[
@@ -67,7 +72,7 @@ def _export_file(folder_path, exportable: Exportable, config: ExportConfig):
     if isinstance(exportable, Model):
         output_format = output_format if output_format else config.default_model_format
 
-    output_file_name = _format_part_name(exportable.file_name, config.output_naming_format, output_format)
+    output_file_name = _format_part_name(exportable.file_name, config.output_naming_format, output_format, exportable.user_args)
 
     formatted_folder_path = _format_path_name(folder_path, config.output_naming_format)
     output_directory = config.output_directory + formatted_folder_path + '/'
@@ -86,7 +91,7 @@ def _export_file(folder_path, exportable: Exportable, config: ExportConfig):
     if (process.returncode == 0):
         output = 'Finished exporting: ' + formatted_folder_path + '/' + output_file_name
         for count in range(2, exportable.quantity + 1):
-            part_copy_name = _format_part_name(exportable.file_name, config.output_naming_format, output_format, count)
+            part_copy_name = _format_part_name(exportable.file_name, config.output_naming_format, output_format, exportable.user_args, count)
             shutil.copy(output_directory + output_file_name, output_directory + part_copy_name)
             output += '\nFinished exporting: ' + formatted_folder_path + '/' + part_copy_name
     else:

--- a/src/scad_export/export.py
+++ b/src/scad_export/export.py
@@ -68,11 +68,11 @@ def _get_exportable_args(exportable: Exportable, config: ExportConfig):
     return args
 
 def _export_file(folder_path, exportable: Exportable, config: ExportConfig):
-    output_format = exportable.output_format
+    file_format = exportable.file_format
     if isinstance(exportable, Model):
-        output_format = output_format if output_format else config.default_model_format
+        file_format = file_format if file_format else config.default_model_format
 
-    output_file_name = _format_part_name(exportable.file_name, config.output_naming_format, output_format, exportable.user_args)
+    output_file_name = _format_part_name(exportable.file_name, config.output_naming_format, file_format, exportable.user_args)
 
     formatted_folder_path = _format_path_name(folder_path, config.output_naming_format)
     output_directory = config.output_directory + formatted_folder_path + '/'
@@ -91,7 +91,7 @@ def _export_file(folder_path, exportable: Exportable, config: ExportConfig):
     if (process.returncode == 0):
         output = 'Finished exporting: ' + formatted_folder_path + '/' + output_file_name
         for count in range(2, exportable.quantity + 1):
-            part_copy_name = _format_part_name(exportable.file_name, config.output_naming_format, output_format, exportable.user_args, count)
+            part_copy_name = _format_part_name(exportable.file_name, config.output_naming_format, file_format, exportable.user_args, count)
             shutil.copy(output_directory + output_file_name, output_directory + part_copy_name)
             output += '\nFinished exporting: ' + formatted_folder_path + '/' + part_copy_name
     else:

--- a/src/scad_export/exportable.py
+++ b/src/scad_export/exportable.py
@@ -38,7 +38,6 @@ class Exportable():
         self.output_format = output_format
         self.quantity = quantity
         self.user_args = kwargs if kwargs else {}
-        self.user_args['name'] = name
 
 class Model(Exportable):
     def __init__(self, name, file_name = None, quantity = 1, format: ModelFormat = None, **kwargs):

--- a/src/scad_export/exportable.py
+++ b/src/scad_export/exportable.py
@@ -32,10 +32,10 @@ class Folder():
         self.contents = contents
 
 class Exportable():
-    def __init__(self, name, output_format, file_name = None, quantity = 1, **kwargs):
+    def __init__(self, name, file_format, file_name = None, quantity = 1, **kwargs):
         self.name = name
         self.file_name = file_name if file_name else name
-        self.output_format = output_format
+        self.file_format = file_format
         self.quantity = quantity
         self.user_args = kwargs if kwargs else {}
 
@@ -55,4 +55,4 @@ class Image(Exportable):
         self.image_size = image_size
         self.color_scheme = color_scheme
         self.camera_position = camera_position
-        super().__init__(name = name, output_format = '.png', file_name = file_name, **kwargs)
+        super().__init__(name = name, file_format = '.png', file_name = file_name, **kwargs)

--- a/tests/examples/README.md
+++ b/tests/examples/README.md
@@ -24,6 +24,8 @@ The output of this example is identical to `export_example.py`. Since the models
 
 Demonstrates using the `Drawing` type to export a 2D circle to DXF. Drawings only support 2D types, but the usage is otherwise similar to `Model`.
 
+This example also demonstrates setting the "quantity", which creates the given number of copies of the file (3 copies in this example).
+
 #### [`image_export_example.py`](image_export_example.py)
 
 Shows how to use the `Image` export type to export images of a model to PNG.

--- a/tests/examples/drawing_export_example.py
+++ b/tests/examples/drawing_export_example.py
@@ -6,6 +6,7 @@ exportables=Folder(
     contents=[
         Drawing(
             name='circle',
+            quantity=3,
             diameter=10
         )
     ]

--- a/tests/examples/export_example.py
+++ b/tests/examples/export_example.py
@@ -11,25 +11,25 @@ exportables=Folder(
             contents=[
                 # Override file_name to export each cube to a separate file, rather than overwriting the same file.
                 # x, y, and z are user-defined arguments that are passed to the export .scad file.
-                Model(name='cube', file_name='cube_5', x=5, y=5, z=5),
-                Model(name='cube', file_name='cube_10', x=10, y=10, z=10),
-                Model(name='cube', file_name='cube_15', x=15, y=15, z=15)
+                Model(name='cube', x=5, y=5, z=5),
+                Model(name='cube', x=10, y=10, z=10),
+                Model(name='cube', x=15, y=15, z=15)
             ]
         ),
         Folder(
             name='cylinders',
             contents=[
-                Model(name='cylinder', file_name='cylinder_10', d=10, z=10),
-                Model(name='cylinder', file_name='cylinder_20', d=10, z=20),
-                Model(name='cylinder', file_name='cylinder_30', d=10, z=30)
+                Model(name='cylinder', d=10, z=10),
+                Model(name='cylinder', d=10, z=20),
+                Model(name='cylinder', d=10, z=30)
             ]
         ),
         Folder(
             name='spheres',
             contents=[
-                Model(name='sphere', file_name='sphere_15', d=15),
-                Model(name='sphere', file_name='sphere_20', d=20),
-                Model(name='sphere', file_name='sphere_25', d=25)
+                Model(name='sphere', d=15),
+                Model(name='sphere', d=20),
+                Model(name='sphere', d=25)
             ]
         )
     ]

--- a/tests/examples/export_example_2.py
+++ b/tests/examples/export_example_2.py
@@ -6,15 +6,15 @@ exportables=Folder(
     contents=[
         Folder(
             name='cubes',
-            contents=[Model(name='cube', file_name='cube_{}'.format(size), x=size, y=size, z=size) for size in range(5, 16, 5)]
+            contents=[Model(name='cube', x=size, y=size, z=size) for size in range(5, 16, 5)]
         ),
         Folder(
             name='cylinders',
-            contents=[Model(name='cylinder', file_name='cylinder_{}'.format(height), d=10, z=height) for height in range(10, 31, 10)]
+            contents=[Model(name='cylinder', d=10, z=height) for height in range(10, 31, 10)]
         ),
         Folder(
             name='spheres',
-            contents=[Model(name='sphere', file_name='sphere_{}'.format(diameter), d=diameter) for diameter in range(15, 26, 5)]
+            contents=[Model(name='sphere', d=diameter) for diameter in range(15, 26, 5)]
         )
     ]
 )


### PR DESCRIPTION
- Automatically format user args into the file name. This prevents an issue where if a model is exported in multiple sizes, each export could overwrite the previous if the file name was not specifically overridden.
- Expand the `NamingFormat` documentation in the readme.
- Rename internal `output_format` and `format` to `file_format` for clarity.